### PR TITLE
Included endogenous labor supply and S periods

### DIFF
--- a/scripts/SS.py
+++ b/scripts/SS.py
@@ -18,10 +18,13 @@ def solve_ss(r_init, w_init, params):
     w = w_init
     while (ss_dist > ss_tol) & (ss_iter < ss_max_iter):
         # solve HH problem
-        foc_args = (beta, sigma, r, w, n, 0.0)
-        b_sp1_guess = [0.05, 0.05]
-        result = opt.root(hh.FOCs, b_sp1_guess, args=foc_args)
-        b_sp1 = result.x
+        foc_args = (beta, sigma, r, w, 0.0)
+        r_s_guess = np.ones(S)
+        b_sp1_guess = np.ones(S-1) * 0.5
+        HH_guess = np.append(b_sp1_guess, r_s_guess)
+        result = opt.root(hh.FOCs, HH_guess, args=foc_args)
+        b_sp1 = result.x[0: S-1]
+        n_s = result.x[S-1:]
         euler_errors = result.fun
         b_s = np.append(0.0, b_sp1)
         # use market clearing

--- a/scripts/SS.py
+++ b/scripts/SS.py
@@ -19,9 +19,9 @@ def solve_ss(r_init, w_init, params):
     while (ss_dist > ss_tol) & (ss_iter < ss_max_iter):
         # solve HH problem
         foc_args = (beta, sigma, r, w, 0.0)
-        r_s_guess = np.ones(S)
+        n_s_guess = np.ones(S)
         b_sp1_guess = np.ones(S-1) * 0.5
-        HH_guess = np.append(b_sp1_guess, r_s_guess)
+        HH_guess = np.append(b_sp1_guess, n_s_guess)
         result = opt.root(hh.FOCs, HH_guess, args=foc_args)
         b_sp1 = result.x[0: S-1]
         n_s = result.x[S-1:]

--- a/scripts/households.py
+++ b/scripts/households.py
@@ -1,4 +1,5 @@
 import numpy as np
+import elliptical_u_est as ellip
 
 # household functions
 
@@ -14,6 +15,9 @@ def FOCs(b_sp1, n_s, *args):
     Args:
     b_sp1: The savings values for each period. The call to this function should provide initial guesses for this variable.
     n_s: The labor supply values for each period. The call to this function should provide initial guesses for this variable.
+    l_tilde: maximum amount of labor supply
+    chi: scale parameter
+    theta: Frisch elasticity of labor supply
     
     n is not contained in the remaining arguments anymore. If someone decides to change this, please provide detailed documentation
     on why you are doing so.
@@ -23,14 +27,12 @@ def FOCs(b_sp1, n_s, *args):
     foc_errors: A list where the first S-1 values are b2, b3, ..., bS, and the next S values are n1, n2, ..., nS.
     '''
 
-    theta = 0.9 # frisch elasticity of labor
-    l_tilde = 1.0 # Maximum labor supply
-    beta, sigma, r, w, b_init = args
+    beta, sigma, r, w, b_init, l_tilde, chi, theta = args
     b_s = np.append(b_init, b_sp1)  # When working on SS.py, note that b_sp1_guess is now of length S-1
     b_sp1 = np.append(b_sp1, 0.0)
     c = get_c(r, w, n_s, b_s, b_sp1)
     mu_c = mu_cons(c, sigma)
-    mu_n = mu_labor(n_s, chi, l_tilde)
+    mu_n = mu_labor(n_s, l_tilde, chi, theta)
     
     # First get the Euler equations defined by Equation (4.10) - S-1 of these
     lhs_euler_b = mu_c
@@ -69,12 +71,12 @@ def mu_cons(c, sigma):
 
     return mu_c
 
-def mu_labor(n, chi, *args):
+def mu_labor(n_s, l_tilde, chi, theta):
     '''
     Computes marginal utility with respect to labor supply
     '''
 
-    b, nu = elliptical_u_est.estimator(theta, l_tilde) # b is the constant defined in Equation (4.9) - has nothing to do with savings
-    mu_n = chi * (b / l_tilde) * (n_s / l_tilde) ** (nu - 1) * (1 - (n_s / l_tilde) ** nu) ** ((1 - nu) / nu )
+    b_ellipse, nu = ellip.estimation(theta, l_tilde) # b_ellipse is the constant defined in Equation (4.9) - has nothing to do with savings
+    mu_n = chi * (b_ellipse / l_tilde) * (n_s / l_tilde) ** (nu - 1) * (1 - (n_s / l_tilde) ** nu) ** ((1 - nu) / nu )
 
     return mu_n

--- a/scripts/households.py
+++ b/scripts/households.py
@@ -3,20 +3,47 @@ import numpy as np
 # household functions
 
 
-def FOCs(b_sp1, *args):
+def FOCs(b_sp1, n_s, *args):
     '''
-    Use the HH FOCs to solve for optimal saves, b2 and b3
-    (1) u'(c1) = beta * (1 + r)* u'(c2) -> b2
-    (2) u'(c2) = beta * (1 + r)* u'(c3) -> b3
+    For the S-period problem, we have 2S-1 FOCs corresponding to the savings variable b, and the labor supply variable n
+    Note that we were dealing with three dimensional vectors earlier. We now have an S-1 dim vector corresponding 
+    to b, and an S dim vector corresponding to n.
+
+    Refer to equations (4.9) and (4.10) of chapter 4 for details on where the variables foc_errors_b and foc_errors_n are coming from
+
+    Args:
+    b_sp1: The savings values for each period. The call to this function should provide initial guesses for this variable.
+    n_s: The labor supply values for each period. The call to this function should provide initial guesses for this variable.
+    
+    n is not contained in the remaining arguments anymore. If someone decides to change this, please provide detailed documentation
+    on why you are doing so.
+
+
+    Returns:
+    foc_errors: A list where the first S-1 values are b2, b3, ..., bS, and the next S values are n1, n2, ..., nS.
     '''
-    beta, sigma, r, w, n, b_init = args
-    b_s = np.append(b_init, b_sp1)
+
+    theta = 0.9 # frisch elasticity of labor
+    l_tilde = 1.0 # Maximum labor supply
+    beta, sigma, r, w, b_init = args
+    b_s = np.append(b_init, b_sp1)  # When working on SS.py, note that b_sp1_guess is now of length S-1
     b_sp1 = np.append(b_sp1, 0.0)
-    c = get_c(r, w, n, b_s, b_sp1)
-    mu_c = u_prime(c, sigma)
-    lhs_euler = mu_c
-    rhs_euler = beta * (1+r) * mu_c
-    foc_errors = lhs_euler[:-1] - rhs_euler[1:]
+    c = get_c(r, w, n_s, b_s, b_sp1)
+    mu_c = mu_cons(c, sigma)
+    mu_n = mu_labor(n_s, chi, l_tilde)
+    
+    # First get the Euler equations defined by Equation (4.10) - S-1 of these
+    lhs_euler_b = mu_c
+    rhs_euler_b = beta * (1+r) * mu_c
+    foc_errors_b = lhs_euler[:-1] - rhs_euler[1:]    
+    # The above line doesn't need to be changed since it works for a general S as well (writing out the vectors helps to see this)
+
+    # Next get the Euler equations defined by (4.9) - S of these
+    lhs_euler_n = w * mu_c
+    rhs_euler_n = mu_n
+    foc_errors_n = lhs_euler_n - rhs_euler_n
+
+    foc_errors = np.append(foc_errors_b, foc_errors_n)
     
     return foc_errors
 
@@ -33,6 +60,9 @@ def get_c(r, w, n, b_s, b_sp1):
 
 def mu_cons(c, sigma):
     '''
+    Computes marginal utility with respect to consumption.
+
+    Please note that this was initially called u_prime. If anyone finds function calls on u_prime, please change it to mu_cons
     Marginal utility of consumption
     '''
     mu_c = c ** -sigma
@@ -41,33 +71,10 @@ def mu_cons(c, sigma):
 
 def mu_labor(n, chi, *args, b_sp1):
     '''
-    Use FOC's for disutilitity of labor to get labor supply
-    
-    Refer to eqn 4.9 of ch 4 for the calculation of the 
-    marginal utility of labor calculation
-    
-    n = household labor supply
-    chi = utility weight on labor supply
-    
-    This model solves for the wage rate (w) given the exogeneous nature
-    of labor supply
-    
-    There will be S labor supply Euler equations below
-    
-    ''' 
-    
-    theta = 0.9 # frisch elasticity of labor
-    l_tilde = 1.0 # Maximum labor supply
-    
-    b, nu = elliptical_u_est.estimator(theta, l_tilde)
-    beta, sigma, r, w, n, b_init = args
-    b_s = np.append(b_init, b_sp1)
-    b_sp1 = np.append(b_sp1, 0.0)
-    c = get_c(r, w, n, b_s, b_sp1)
-    mu_c = u_prime(c, sigma)
-    
-    lhs = w * mu_c
-    rhs = chi * (b / l_tilde) * (n / l_tilde) ** (nu - 1) * (1 - (n / l_tilde) ** nu) ** ((1 - nu) / nu )
-    foc_errors = lhs - rhs
-    
-    return foc_errors
+    Computes marginal utility with respect to labor supply
+    '''
+
+    b, nu = elliptical_u_est.estimator(theta, l_tilde) # b is the constant defined in Equation (4.9) - has nothing to do with savings
+    mu_n = chi * (b / l_tilde) * (n_s / l_tilde) ** (nu - 1) * (1 - (n_s / l_tilde) ** nu) ** ((1 - nu) / nu )
+
+    return mu_n

--- a/scripts/households.py
+++ b/scripts/households.py
@@ -35,7 +35,7 @@ def FOCs(b_sp1, n_s, *args):
     # First get the Euler equations defined by Equation (4.10) - S-1 of these
     lhs_euler_b = mu_c
     rhs_euler_b = beta * (1+r) * mu_c
-    foc_errors_b = lhs_euler[:-1] - rhs_euler[1:]    
+    foc_errors_b = lhs_euler_b[:-1] - rhs_euler_b[1:]    
     # The above line doesn't need to be changed since it works for a general S as well (writing out the vectors helps to see this)
 
     # Next get the Euler equations defined by (4.9) - S of these
@@ -69,7 +69,7 @@ def mu_cons(c, sigma):
 
     return mu_c
 
-def mu_labor(n, chi, *args, b_sp1):
+def mu_labor(n, chi, *args):
     '''
     Computes marginal utility with respect to labor supply
     '''


### PR DESCRIPTION
I've modified the households.py and SS.py files to incorporate both endogenous labor supply and S-periods. The earlier version of households.py didn't simultaneously account for all 2S-1 FOCs. I have also fixed some typos and cleaned up the code a bit.